### PR TITLE
Added the ability to include custom headers in the filename

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var join = require('path').join;
+var Combinatorics = require('js-combinatorics').Combinatorics;
 
 var parseStatus = function (header) {
     return header.split(' ')[1];
@@ -34,7 +35,6 @@ var parse = function (content) {
 };
 
 var mockserver = {
-    variationHeader: "mockserver-variation",
     directory:       ".",
     use:             function(directory) {
         this.directory = directory;
@@ -45,26 +45,53 @@ var mockserver = {
 
         var queryIndex = url.indexOf('?'),
             query = queryIndex >= 0 ? url.substring(queryIndex).replace(/\?/g, '--') : '',
-            method = req.method.toUpperCase();
+            method = req.method.toUpperCase(),
+            headers = [];
 
         if (queryIndex > 0) {
             path = url.substring(0, queryIndex);
         }
 
-        if (req.headers && req.headers[mockserver.variationHeader]) {
-            method += '_' + req.headers[mockserver.variationHeader];
+        var watchedHeaders = module.exports.headers;
+        if(watchedHeaders && !Array.isArray(watchedHeaders)) {
+            watchedHeaders = [watchedHeaders];
+        }
+        if(req.headers && watchedHeaders && watchedHeaders.length) {
+            watchedHeaders.forEach(function(header) {
+                if(req.headers[header]) {
+                    headers.push('_' + header + '=' + req.headers[header]);
+                }
+            });
         }
 
-        var mockName =  method + query + '.mock';
-        var mockFile = join(mockserver.directory, path, mockName);
 
-        try {
-            var content = fs.readFileSync(mockFile, {encoding: 'utf8'});
+        // Now, permute the possible headers, and look for any matching files, prioritizing on
+        // both # of headers and the original header order
+        var content,
+            permutations = [[]];
+        if(headers.length) {
+            permutations = Combinatorics.permutationCombination(headers).toArray().sort(function(a, b) {return b.length - a.length});
+            permutations.push([]);
+        }
+        while(permutations.length) {
+            var mockName =  method + permutations.pop().join('') + query + '.mock';
+            var mockFile = join(mockserver.directory, path, mockName);
+            if(fs.existsSync(mockFile)) {
+                try {
+                    content = fs.readFileSync(mockFile, {encoding: 'utf8'});
+                } catch(err) {
+                    // ignore file read errors, maybe we matched something by accident
+                }
+            }
+        }
+
+
+        if(content) {
             var mock = parse(content);
             res.writeHead(mock.status, mock.headers);
 
             return res.end(mock.body);
-        } catch (err) {
+        } else {
             res.writeHead(404);
             res.end('Not Mocked');
         }
@@ -76,3 +103,5 @@ module.exports = function(directory){
 
     return mockserver.handle;
 };
+
+module.exports.headers = [];

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "homepage": "https://github.com/namshi/mockserver",
   "dependencies": {
-    "mocha": "*"
+    "js-combinatorics": "^0.4.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.0.1"
   }
 }

--- a/test/mocks/request-headers/GET.mock
+++ b/test/mocks/request-headers/GET.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 401 NOT AUTHORIZED
+Content-Type: text
+
+not authorized

--- a/test/mocks/request-headers/GET_Authorization=1234.mock
+++ b/test/mocks/request-headers/GET_Authorization=1234.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text
+
+authorized

--- a/test/mocks/request-headers/GET_Authorization=5678.mock
+++ b/test/mocks/request-headers/GET_Authorization=5678.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text
+
+admin authorized

--- a/test/mocks/request-headers/POST_Authorization=12_X-Foo=Bar--a=b.mock
+++ b/test/mocks/request-headers/POST_Authorization=12_X-Foo=Bar--a=b.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text
+
+that is a long filename

--- a/test/mocks/request-headers/PUT_Authorization=12.mock
+++ b/test/mocks/request-headers/PUT_Authorization=12.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text
+
+header auth only

--- a/test/mocks/request-headers/PUT_Authorization=12_X-Foo=Bar.mock
+++ b/test/mocks/request-headers/PUT_Authorization=12_X-Foo=Bar.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text
+
+header both

--- a/test/mocks/request-headers/PUT_X-Foo=Baz.mock
+++ b/test/mocks/request-headers/PUT_X-Foo=Baz.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text
+
+header x-foo only

--- a/test/mocks/request-headers/PUT_X-Foo=Baz_Authorization=78.mock
+++ b/test/mocks/request-headers/PUT_X-Foo=Baz_Authorization=78.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text
+
+header both out-of-order

--- a/test/mocks/test/GET_failure--a=b.mock
+++ b/test/mocks/test/GET_failure--a=b.mock
@@ -1,4 +1,0 @@
-HTTP/1.1 500 Internal Server Error
-Content-Type: text
-
-Ouch! (with query)

--- a/test/mocks/test/GET_failure.mock
+++ b/test/mocks/test/GET_failure.mock
@@ -1,4 +1,0 @@
-HTTP/1.1 500 Internal Server Error
-Content-Type: text
-
-Ouch!

--- a/test/mocks/test1/test2/GET_400.mock
+++ b/test/mocks/test1/test2/GET_400.mock
@@ -1,4 +1,0 @@
-HTTP/1.1 400 Bad Request
-Content-Type: text
-
-bad request


### PR DESCRIPTION
This PR includes the ability to specify custom headers that should be part of the filename.  For example, you could ask mockserver to include the `Authorization` header, so you can "login" as different users and see different results, like so:

```
var mockserver = require('mockserver');
mockserver.headers = ['Authorization'];
// user mockserver like normal
```

Now, you can have files like this:

```
secure/GET.mock -> 401 NOT AUTHORIZED
login/POST.mock -> returns an auth token for client to store
secure/GET_Authorization=TOKEN.mock -> 200 OK
```

PR includes updated docs and tests, as well.

I also took the liberty to rewrite the tests to use a single function to set up and run the mock tests, to make it easier to focus on the differences.  :smile: 
