### PR TITLE
Allowing mockserver to run as a global command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,24 @@ backend is really ready or not.
 
 ## Installation
 
-Simply install this library through NPM:
+Mockserver can be installed globally if you need
+to run it as a command:
+
+```
+$ npm install -g mockserver
+
+$ mockserver.js -p 9001 -m test/mocks
+Mockserver serving mocks under "test/mocks" at http://localhost:8080
+```
+
+or as a regular NPM mobule if you need to use it as
+a library within your code:
 
 ``` bash
 npm install mockserver
 ```
 
-## Usage
-
-First of all, define where your mocked backend is gonna run:
+then in your test file:
 
 ``` javascript
 var http    =  require('http');

--- a/bin/mockserver.js
+++ b/bin/mockserver.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+var http        = require('http');
+var mockserver  = require('./../mockserver');
+var argv        = require('yargs').argv;
+var colors      = require('colors')
+var info        = require('./../package.json');
+var mocks       = argv.m || argv.mocks;
+var port        = argv.p || argv.port;
+
+if (!mocks || !port) {
+  console.log("Mockserver v" + info.version);
+  console.log();
+  console.log("Usage:   mockserver -p PORT -m /PATH/TO/YOUR/MOCKS");
+  console.log("Example: mockserver -p 8080 -m test/mocks");
+} else {
+  http.createServer(mockserver(mocks)).listen(port);
+  
+  console.log('Mockserver serving mocks under "' + mocks.green  + '" at ' + 'http://localhost:'.green + port.toString().green);
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "mocha"
   },
+  "bin": {
+    "mockserver": "bin/mockserver.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/namshi/mockserver"
@@ -25,7 +28,9 @@
   },
   "homepage": "https://github.com/namshi/mockserver",
   "dependencies": {
-    "js-combinatorics": "^0.4.0"
+    "colors": "^1.0.3",
+    "js-combinatorics": "^0.4.0",
+    "yargs": "^1.3.3"
   },
   "devDependencies": {
     "mocha": "^2.0.1"


### PR DESCRIPTION
This means that you can now run:

```
mockserver -p 8080 -m test/mocks
```

and the server will be up&running.

This is done mostly to let users test
their frontends on a real browser without
the need to write a simple script like:

``` javascript
var http    =  require('http');
var mockserver  =  require('mockserver');

http.createServer(mockserver('path/to/your/mocks')).listen(9001);
```

everytime.
