### PR TITLE
POST body support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ to run it as a command:
 ```
 $ npm install -g mockserver
 
-$ mockserver.js -p 9001 -m test/mocks
+$ mockserver -p 8080 -m test/mocks
 Mockserver serving mocks under "test/mocks" at http://localhost:8080
 ```
 
@@ -136,7 +136,7 @@ The first one matched is the one returned, favoring more matches and headers ear
 
 The `headers` array can be set or modified at any time.
 
-## Query String Parameters
+## Query string parameters and POST body
 
 In order to support query string parameters in the mocked files, replace all occurrences of `?` with `--`, then
 append the entire string to the end of the file.
@@ -163,6 +163,10 @@ Authorization: 12345
 
 hello/GET_Authorization=12345--a=b.mock
 ```
+
+Similarly, you can do the same thing with the body of a POST request:
+if you send `Hello=World` as body of the request, mockserver will
+look for a file called `POST--Hello=World.mock`
 
 ## Tests
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "yargs": "^1.3.3"
   },
   "devDependencies": {
-    "mocha": "^2.0.1"
+    "mocha": "^2.0.1",
+    "mock-req": "^0.2.0"
   }
 }

--- a/test/mocks/return-200/POST--Hello=123.mock
+++ b/test/mocks/return-200/POST--Hello=123.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+
+Hella

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -1,3 +1,4 @@
+var MockReq = require('mock-req');
 var assert = require("assert");
 var mockserver = require("./../mockserver");
 
@@ -25,7 +26,12 @@ describe('mockserver', function() {
         req = {
             url: null,
             method: null,
-            headers: []
+            headers: [],
+            on: function(event, cb) {
+              if (event === 'end') {
+                cb();
+              }
+            }
         }
     });
 
@@ -172,6 +178,25 @@ describe('mockserver', function() {
               );
             assert.equal(res.status, 200);
             assert.equal(JSON.stringify(res.headers), '{"Content-Type":"text/plain; charset=utf-8"}');
+        });
+        it('should be able to include POST bodies in the mock location', function(done) {
+            var req = new MockReq({
+                method: 'POST',
+                url: '/return-200',
+                headers: {
+                    'Accept': 'text/plain'
+                }
+            });
+            req.write('Hello=123')
+            req.end();
+            
+            mockserver(mocksDirectory)(req, res);
+            
+            req.on('end', function(){
+              assert.equal(res.body, 'Hella');
+              assert.equal(res.status, 200);
+              done();
+            })
         });
     })
 });


### PR DESCRIPTION
* tests are a bit quirky so I guess we should wait a bit till someone tests this in their own codebase (I tried a couple things locally, tests pass, and also manual CURL requests are fine)
* added the ability to support the body of a POST request just like we do with GET parameters (`/POST--My-Post-Body.mock`)
* covered it with tests (had to use `mock-req` as the request, in this case, needs to be a stream -- it would be a good thing to convert all tests to that)
* updated the README
* added some jsdoc

Open to suggestions :)