### PR TITLE
enable the ability to have JS files that product a mock

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -140,7 +140,6 @@ function getMockedContent(path, prefix, body, query) {
         foundFile.isJS = true;
         return foundFile;
     } catch(err) {
-        console.log(err)
     }
 
     var mockedMockName =  prefix + (getBodyOrQueryString(body, query) || '') + '.mock';

--- a/mockserver.js
+++ b/mockserver.js
@@ -134,13 +134,13 @@ function getBody(req, callback) {
 function getMockedContent(path, prefix, body, query) {
     var mockedJSName =  prefix + (getBodyOrQueryString(body, query) || '') + '.js';
     var mockJSFile = join(mockserver.directory, path, mockedJSName);
+
     try {
         var foundFile = require(process.cwd() + '/' + mockJSFile);
         foundFile.isJS = true;
         return foundFile;
     } catch(err) {
         console.log(err)
-        return (body || query) && getMockedContent(path, prefix);
     }
 
     var mockedMockName =  prefix + (getBodyOrQueryString(body, query) || '') + '.mock';


### PR DESCRIPTION
If the JS file exports an object that contains headers, status and a body, that will be used to generate a mock, this will allow mocks to be used across unit tests and the main site.