### PR TITLE
Fix headers according to HTTP/1.1 RFC

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var join = require('path').join;
 var Combinatorics = require('js-combinatorics');
+var normalizeHeader = require('header-case-normalizer');
 
 /**
  * Returns the status code out of the
@@ -18,7 +19,7 @@ var parseStatus = function (header) {
 var parseHeader = function (header) {
     header = header.split(': ');
 
-    return {key: header[0], value: header[1]};
+    return {key: normalizeHeader(header[0]), value: header[1]};
 };
 
 /**
@@ -136,8 +137,9 @@ var mockserver = {
         }
         if(req.headers && watchedHeaders && watchedHeaders.length) {
             watchedHeaders.forEach(function(header) {
+                header = header.toLowerCase();
                 if(req.headers[header]) {
-                    headers.push('_' + header + '=' + req.headers[header]);
+                    headers.push('_' + normalizeHeader(header) + '=' + req.headers[header]);
                 }
             });
         }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "colors": "^1.0.3",
     "js-combinatorics": "^0.5.0",
-    "yargs": "^1.3.3"
+    "yargs": "^1.3.3",
+    "header-case-normalizer": "^1.0.3"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -118,71 +118,71 @@ describe('mockserver', function() {
         });
 
         it('should be able track custom headers', function() {
-            mockserver.headers = ['Authorization'];
+            mockserver.headers = ['authorization'];
 
             process('/request-headers', 'GET');
             assert.equal(res.status, 401);
             assert.equal(res.body, 'not authorized');
 
-            req.headers['Authorization'] = '1234';
+            req.headers['authorization'] = '1234';
             process('/request-headers', 'GET');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'authorized');
 
-            req.headers['Authorization'] = '5678';
+            req.headers['authorization'] = '5678';
             process('/request-headers', 'GET');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'admin authorized');
         });
 
         it('should attempt to fall back to a base method if a custom header is not found in a file', function() {
-            mockserver.headers = ['Authorization'];
+            mockserver.headers = ['authorization'];
 
-            req.headers['Authorization'] = 'invalid';
+            req.headers['authorization'] = 'invalid';
             process('/request-headers', 'GET');
             assert.equal(res.status, 401);
             assert.equal(res.body, 'not authorized');
 
-            req.headers['Authorization'] = 'invalid';
+            req.headers['authorization'] = 'invalid';
             process('/request-headers', 'POST');
             assert.equal(res.status, 404);
             assert.equal(res.body, 'Not Mocked');
         });
 
         it('should look for alternate combinations of headers if a custom header is not found', function() {
-            mockserver.headers = ['Authorization', 'X-Foo'];
+            mockserver.headers = ['authorization', 'x-foo'];
 
-            req.headers['Authorization'] = 12;
-            req.headers['X-Foo'] = 'Bar';
+            req.headers['authorization'] = 12;
+            req.headers['x-foo'] = 'Bar';
             process('/request-headers', 'PUT');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'header both');
 
-            req.headers['X-Foo'] = 'Baz';
+            req.headers['x-foo'] = 'Baz';
             process('/request-headers', 'PUT');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'header auth only');
 
-            req.headers['Authorization'] = 78;
+            req.headers['authorization'] = 78;
             process('/request-headers', 'PUT');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'header both out-of-order');
 
-            req.headers['Authorization'] = 45;
+            req.headers['authorization'] = 45;
             process('/request-headers', 'PUT');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'header x-foo only');
 
-            delete req.headers['Authorization'];
+            delete req.headers['authorization'];
             process('/request-headers', 'PUT');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'header x-foo only');
         });
 
         it('should be able track custom headers with variation and query params', function() {
-            mockserver.headers = ['Authorization', 'X-Foo'];
-            req.headers['Authorization'] = 12;
-            req.headers['X-Foo'] = 'Bar';
+            mockserver.headers = ['authorization', 'x-foo'];
+            req.headers['authorization'] = 12;
+            req.headers['x-foo'] = 'Bar';
             process('/request-headers?a=b', 'POST');
             assert.equal(res.status, 200);
             assert.equal(res.body, 'that is a long filename');
@@ -263,8 +263,8 @@ describe('mockserver', function() {
         });
 
         it('Should return 404 when no default .mock files are found', function() {
-            mockserver.headers = ['Authorization'];
-            req.headers['Authorization'] = 12;
+            mockserver.headers = ['authorization'];
+            req.headers['authorization'] = 12;
             process('/return-200?a=c', 'GET');
 
             assert.equal(res.status, 404);


### PR DESCRIPTION
HTTP headers are case insensitive and NodeJS makes them lower case by default.
Added header-case-normalizer to normalize response headers and keep backward-compatible for mock filenames.