### PR TITLE
Fix null.toString() call

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -27,7 +27,8 @@ var parseHeader = function (header) {
  * Priority exports over ENV definition.
  */
 var prepareWatchedHeaders = function () {
-    var headers = (module.exports.headers.toString() || process.env.MOCK_HEADERS || '').split(',');
+    var exportHeaders = module.exports.headers && module.exports.headers.toString();
+    var headers = (exportHeaders || process.env.MOCK_HEADERS || '').split(',');
 
     return headers.filter(function(item, pos, self) {
         return item && self.indexOf(item) == pos;


### PR DESCRIPTION
Fix epic fail for #22 PR.

```shell
$ ./bin/mockserver.js -p 8080 -m test/mocks
/home/user/api-mocks/node_modules/mockserver/mockserver.js:30
        var headers = (module.exports.headers.toString() || process.env.MOCK_HEADERS || '').split(',');
TypeError: Cannot read property 'toString' of null
```