### PR TITLE
Support for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ look for a file called `POST--Hello=World.mock`
 
 In the same way, if your POST body is a json like `{"json": "yesPlease"}`,
 mockserver will look for a file called `POST--{"json": "yesPlease"}.mock`
+*Warning! This feature is NOT compatible with Windows. This is because Windows doesn't accept curly braces as filenames.*
 
 If no parametrized mock file is found, mockserver will default to the
 nearest headers based .mock file

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ look for a file called `POST--Hello=World.mock`
 
 In the same way, if your POST body is a json like `{"json": "yesPlease"}`,
 mockserver will look for a file called `POST--{"json": "yesPlease"}.mock`.
-*Warning! This feature is _NOT compatible with Windows_. This is because Windows doesn't accept curly brackets as filenames.*
+*Warning! This feature is* __NOT compatible with Windows__*. This is because Windows doesn't accept curly brackets as filenames.*
 
 If no parametrized mock file is found, mockserver will default to the
 nearest headers based .mock file

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ if you send `Hello=World` as body of the request, mockserver will
 look for a file called `POST--Hello=World.mock`
 
 In the same way, if your POST body is a json like `{"json": "yesPlease"}`,
-mockserver will look for a file called `POST--{"json": "yesPlease"}.mock`
-*Warning! This feature is NOT compatible with Windows. This is because Windows doesn't accept curly braces as filenames.*
+mockserver will look for a file called `POST--{"json": "yesPlease"}.mock`.
+*Warning! This feature is _NOT compatible with Windows_. This is because Windows doesn't accept curly brackets as filenames.*
 
 If no parametrized mock file is found, mockserver will default to the
 nearest headers based .mock file

--- a/test/mocks/return-200/POST--{"json": "yesPlease"}.mock
+++ b/test/mocks/return-200/POST--{"json": "yesPlease"}.mock
@@ -1,6 +1,0 @@
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "json": "yes, we haZ it"
-}

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -275,28 +275,6 @@ describe('mockserver', function() {
             });
         });
 
-        it('should be able to include POST json in the mock location', function(done) {
-            var req = new MockReq({
-                method: 'POST',
-                url: '/return-200',
-                headers: {
-                    'Accept': 'application/json'
-                }
-            });
-            req.write('{"json": "yesPlease"}');
-            req.end();
-
-            mockserver(mocksDirectory, verbose)(req, res);
-
-            req.on('end', function() {
-              var jsonBody = JSON.parse(res.body);
-              
-              assert.equal(jsonBody.json, 'yes, we haZ it');
-              assert.equal(res.status, 200);
-              done();
-            });
-        });
-
         it('Should default to POST.mock if no match for body is found', function(done) {
             var req = new MockReq({
                 method: 'POST',


### PR DESCRIPTION
As other issues are reporting, mockserver doesn't work with Windows. This is because the file ``POST--{"json": "yesPlease"}.mock``. The curly brackets are not valid characters for file names in Windows. In order to provide support for Windows I can only think about removing the test file, but keep everything untouched so other architectures can use that functionality. I also added a warning in ``README.md`` to warn about this incompatibility issue.

Thanks for maintaining this repository :)