### PR TITLE
Fixed a problem with line endings on Windows

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -74,7 +74,8 @@ var parse = function (content, file) {
             var importThisFile = file.replace(/['"]/g, '');
 
             return fs.readFileSync(path.join('./', context, importThisFile));
-        });
+        })
+        .replace(/\r\n?/g, '\n');
     }
 
     return {status: status, headers: headers, body: body};

--- a/mockserver.js
+++ b/mockserver.js
@@ -45,7 +45,7 @@ var parse = function (content, file) {
     var headers         = {};
     var body;
     var bodyContent     = [];
-    content             = content.split('\n');
+    content             = content.split(/\r?\n/);
     var status          = parseStatus(content[0]);
     var headerEnd       = false;
     delete content[0];


### PR DESCRIPTION
There's a bit of a problem with Windows line endings in *.mock files when you use mockserver on Windows.
It crashes with an error 'TypeError: The header content contains invalid characters'.
Here's a tiny fix to prevent it.