### PR TITLE
Use directories named '__' as wildcards, to match '/resource/:id' style routing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,30 @@ Authorization: 12345
 ```
 if there's no `hello/GET_Authorization=12345--a=b.mock`, we'll default to `hello/GET_Authorization=12345.mock` or to `hello/GET.mock`
 
+## Wildcard slugs
+
+If you want to match against a route with a wildcard - say in the case of an ID or other parameter in the URL, you can
+create a directory named `__` as a wildcard.
+
+For example, let's say that you want mock the response of a GET request
+to `/users/:id`, you can create files named `users/1/GET.mock`, `users/2/GET.mock`, `users/3/GET.mock`, etc.
+
+Then to create one catchall, you can create another file `users/__/GET.mock`. This file will act as a fallback
+for any other requests:
+
+ex:
+```
+GET /users/2
+
+GET /users/2/GET.mock
+```
+
+ex:
+```
+GET /users/1000
+
+GET /users/__/GET.mock
+```
 
 ## Custom imports
 Say you have some json you want to use in your unit tests, and also serve as the body of the call. You can use this import syntax:

--- a/mockserver.js
+++ b/mockserver.js
@@ -81,6 +81,26 @@ var parse = function (content, file) {
     return {status: status, headers: headers, body: body};
 };
 
+function removeBlanks(array) {
+  return array.filter(function (i) { return i; });
+}
+
+function getWildcardPath(path) {
+  var steps = removeBlanks(path.split('/')),
+      testPath,
+      newPath,
+      exists = false;
+
+    while(steps.length && !newPath) {
+        steps.pop();
+        testPath = join(steps.join('/'), '/__');
+        exists = fs.existsSync(join(mockserver.directory, testPath));
+        if(exists) { newPath = testPath; }
+    }
+
+    return newPath;
+}
+
 /**
  * Returns the body or query string to be used in
  * the mock name.
@@ -150,6 +170,17 @@ function getMockedContent(path, prefix, body, query) {
     return content;
 }
 
+function getContentFromPermutations(path, method, body, query, permutations) {
+    var content, prefix;
+
+    while(permutations.length) {
+        prefix = method + permutations.pop().join('');
+        content = getMockedContent(path, prefix, body, query) || content;
+    }
+
+    return { content: content, prefix: prefix };
+}
+
 var mockserver = {
     directory:       '.',
     verbose:         false,
@@ -184,7 +215,7 @@ var mockserver = {
 
         // Now, permute the possible headers, and look for any matching files, prioritizing on
         // both # of headers and the original header order
-        var content,
+        var matched,
             permutations = [[]];
 
         if(headers.length) {
@@ -192,13 +223,14 @@ var mockserver = {
             permutations.push([]);
         }
 
-        while(permutations.length) {
-            var prefix = method + permutations.pop().join('');
-            content = getMockedContent(path, prefix, body, query) || content;
+        matched = getContentFromPermutations(path, method, body, query, permutations.slice(0));
+
+        if(!matched.content && (path = getWildcardPath(path))) {
+            matched = getContentFromPermutations(path, method, body, query, permutations.slice(0));
         }
 
-        if(content) {
-            var mock = parse(content, join(mockserver.directory, path, prefix));
+        if(matched.content) {
+            var mock = parse(matched.content, join(mockserver.directory, path, matched.prefix));
             res.writeHead(mock.status, mock.headers);
 
             return res.end(mock.body);

--- a/test/mocks/wildcard/__/GET.mock
+++ b/test/mocks/wildcard/__/GET.mock
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+
+this always comes up

--- a/test/mocks/wildcard/exact/GET.mock
+++ b/test/mocks/wildcard/exact/GET.mock
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+
+more specific

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -315,5 +315,34 @@ describe('mockserver', function() {
             assert.equal(res.status, 200);
             assert.equal(res.body, 'stuff\n'+JSON.stringify({foo: 'bar'}, null, 4)+'\naround me');
         });
+
+        describe('wildcard directories', function() {
+          it('wildcard matches directories named __ with numeric slug', function() {
+              processRequest('/wildcard/123', 'GET');
+
+              assert.equal(res.status, 200);
+              assert.equal(res.body, 'this always comes up\n');
+          });
+
+          it('wildcard matches directories named __ with string slug', function() {
+              processRequest('/wildcard/abc', 'GET');
+
+              assert.equal(res.status, 200);
+              assert.equal(res.body, 'this always comes up\n');
+          });
+
+          it('__ not used if more specific match exist', function() {
+              processRequest('/wildcard/exact', 'GET');
+
+              assert.equal(res.status, 200);
+              assert.equal(res.body, 'more specific\n');
+          });
+
+          it('should not resolve with missing slug', function() {
+              processRequest('/wildcard/', 'GET');
+
+              assert.equal(res.status, 404);
+          });
+        });
     });
 });


### PR DESCRIPTION
In many routing schemes, parameters can be mixed into the URL
as well as the query string. I have a use case where I want to return
the same object every time you hit an endpoint '/users/:id', so this
is my approach.

We just run everything normally as before; if no match is found, we
search the path for any '__' directories and run it again.