### PR TITLE
Adding missing color require in mockserver.js

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -3,6 +3,7 @@ var path = require('path');
 var join = path.join;
 var Combinatorics = require('js-combinatorics');
 var normalizeHeader = require('header-case-normalizer');
+var colors = require('colors')
 
 /**
  * Returns the status code out of the


### PR DESCRIPTION
Without it, verbose mode doesn't print anything, when running from JS.

The way it is, it prints:

Reading from undefined file: undefined