### PR TITLE
Fix an issue where on POSIX-like filesystems first '/' in absolute file path would be lost.

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -74,7 +74,7 @@ var parse = function (content, file) {
         body = body.replace(/^#import (.*);/m, function (includeStatement, file, data) {
             var importThisFile = file.replace(/['"]/g, '');
 
-            return fs.readFileSync(path.join('./', context, importThisFile));
+            return fs.readFileSync(path.join(context, importThisFile));
         })
         .replace(/\r\n?/g, '\n');
     }


### PR DESCRIPTION
Greetings!

I have stumbled across the same issue as #42 and I think I have found the cause.

Using `path.join('./', context, importThisFile)` in the file reading function for `#import` directive of mock files just so happens to be removing the first '/' from the absolute file path on POSIX-like file systems. So instead of `/user/something/whatever/file.json` one would get `user/something/whatever/file.json` which would cause an error.

Since this issue seems to be relatively not very popular I guess it only happens under some circumstances. It appears to be that using just `path.join(context, importThisFile)` will solve this problem. I'm not sure why `path.join('./', context, importThisFile)` was used before since "context" variable is assigned `path.parse(file).dir + '/'` in the code and [NodeJS docks](https://nodejs.org/api/path.html#path_path_parse_path) say it will evaluate to an absolute directory path on both file systems anyway. Please correct me if I'm wrong here.

Please review this and merge if necessary.