### PR TITLE
match multiple wildcards

### DIFF
--- a/mockserver.js
+++ b/mockserver.js
@@ -134,18 +134,30 @@ function getWildcardPath(dir) {
     
     steps = removeBlanks(dir.split('/'))
 
-    for (let index = 0; index < steps.length; index++) {
-        const dupeSteps = removeBlanks(dir.split('/'))
-        dupeSteps[index] = '__'
-        testPath = dupeSteps.join(path.sep)
-        const matchFound =  res.includes(testPath);
-        if (matchFound) {
-            newPath = testPath
-            break
-        }
-    }
+    newPath = matchWildcardPaths(res, steps) || newPath;
 
     return newPath;
+}
+
+function matchWildcardPaths(res, steps) {
+    for (let resIndex = 0; resIndex < res.length; resIndex++) {
+        const dirSteps = res[resIndex].split(/\/|\\/);
+        if (dirSteps.length !== steps.length) { continue; }
+        const result = matchWildcardPath(steps, dirSteps);
+        if (result) { return result; }
+    }
+    return null;
+}
+
+function matchWildcardPath(steps, dirSteps) {
+    for (let stepIndex = 1; stepIndex <= steps.length; stepIndex++) {
+        const step = steps[steps.length - stepIndex];
+        const dirStep = dirSteps[dirSteps.length - stepIndex];
+        if (step !== dirStep && dirStep != '__') {
+            return null;
+        }
+    }
+    return '/' + dirSteps.join('/');
 }
 
 function flattenDeep(directories){

--- a/test/mocks/wildcard-extended/__/foobar/__/fizzbuzz/GET.mock
+++ b/test/mocks/wildcard-extended/__/foobar/__/fizzbuzz/GET.mock
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+
+wildcards-extended-multiple

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -392,6 +392,13 @@ describe('mockserver', function() {
             assert.equal(res.body, 'wildcards-extended');
           });
 
+          it('wildcard matches directories named foo/__/bar/__/fizz', function() {
+            processRequest('/wildcard-extended/abc/foobar/def/fizzbuzz', 'GET');
+
+            assert.equal(res.status, 200);
+            assert.equal(res.body, 'wildcards-extended-multiple');
+          });
+
           it('__ not used if more specific match exist', function() {
               processRequest('/wildcard/exact', 'GET');
 


### PR DESCRIPTION
This attempts to solve #51 by using a different method to match:

1. This method will only match if the path and the directory length match
2. It will only match if every component of the path and directory are the same, _or_ if the directory component is `__`

Tests are green and a new one was added.

Let me know if that's to your liking!