### PR TITLE
Flexible response status codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 test.js
 .nyc_output
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -285,6 +285,27 @@ Dynamic values of headers can be filled with valid JS statements such as:
 X-Subject-Token: #header ${require('uuid/v4')()};
 ```
 
+## Custom response status
+
+You can specify response status (200, 201, 404. etc.) depends on request parameters. To do this, you neeed to use `#import './code.js';` in first line of your mock file:
+
+```
+#import './code.js';
+Content-Type: application/json; charset=utf-8
+Access-Control-Allow-Origin: *
+
+{
+ "Random": "Content" 
+}
+```
+
+You import `javascript` modules to create dynamic code responses:
+
+```js
+// code.js
+module.exports = request.body.indexOf('foo') !== -1 ? 'HTTP/1.1 200 OK' : 'HTTP/1.1 400 Bad request'
+```
+
 ## Tests
 
 Tests run on travis, but if you wanna run them locally you simply

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ X-Subject-Token: #header ${require('uuid/v4')()};
 
 ## Custom response status
 
-You can specify response status (200, 201, 404. etc.) depends on request parameters. To do this, you neeed to use `#import './code.js';` in first line of your mock file:
+You can specify response status (200, 201, 404. etc.) depending on request parameters. To do this, you need to use `#import './code.js';` in first line of your mock file:
 
 ```
 #import './code.js';

--- a/handlers/evalHandler.js
+++ b/handlers/evalHandler.js
@@ -1,0 +1,8 @@
+module.exports = function evalHandler(value, request) {
+  if (!/^#eval/m.test(value)) return value;
+  return value
+    .replace(/^#eval (.*);/m, function (statement, val) {
+    return eval(val);
+  })
+    .replace(/\r\n?/g, '\n');
+}

--- a/handlers/headerHandler.js
+++ b/handlers/headerHandler.js
@@ -1,0 +1,9 @@
+module.exports = function headerHandler(value, request) {
+  if (!/^#header/m.test(value)) return value;
+  return value
+    .replace(/^#header (.*);/m, function (statement, val) {
+    const expression = val.replace(/[${}]/g, '');
+    return eval(expression);
+  })
+    .replace(/\r\n?/g, '\n');
+}

--- a/handlers/importHandler.js
+++ b/handlers/importHandler.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function importHandler(value, context, request) {
+    if (!/^#import/m.test(value)) return value;
+
+    return value
+      .replace(/^#import (.*);/m, function (includeStatement, file) {
+          const importThisFile = file.replace(/['"]/g, '');
+          const content = fs.readFileSync(path.join(context, importThisFile));
+          if (importThisFile.endsWith('.js')) {
+              return JSON.stringify(eval(content.toString()));
+          } else {
+              return content;
+          }
+      })
+      .replace(/\r\n?/g, '\n');
+}

--- a/mockserver.js
+++ b/mockserver.js
@@ -60,7 +60,24 @@ const parse = function(content, file, request) {
   let body;
   const bodyContent = [];
   content = content.split(/\r?\n/);
-  const status = parseStatus(content[0]);
+  let status = content[0];
+  if (/^#import/m.test(status)) {
+      const context = path.parse(file).dir + '/';
+
+      status = parseStatus(status
+          .replace(/^#import (.*);/m, function (includeStatement, file) {
+              const importThisFile = file.replace(/['"]/g, '');
+              const content = fs.readFileSync(path.join(context, importThisFile));
+              if (importThisFile.endsWith('.js')) {
+                  return JSON.stringify(eval(content.toString()));
+              } else {
+                  return content;
+              }
+          })
+          .replace(/\r\n?/g, '\n'));
+  } else {
+      status = parseStatus(content[0]);
+  }
   let headerEnd = false;
   delete content[0];
 

--- a/mockserver.js
+++ b/mockserver.js
@@ -4,36 +4,40 @@ const colors = require('colors');
 const join = path.join;
 const Combinatorics = require('js-combinatorics');
 const normalizeHeader = require('header-case-normalizer');
-
+const Monad = require('./monad');
+const importHandler = require('./handlers/importHandler');
+const headerHandler = require('./handlers/headerHandler');
+const evalHandler = require('./handlers/evalHandler');
 /**
  * Returns the status code out of the
  * first line of an HTTP response
  * (ie. HTTP/1.1 200 Ok)
  */
 function parseStatus(header) {
-  return header.split(' ')[1];
+  const regex = /(?<=HTTP\/\d.\d\s{1,1})(\d{3,3})(?=[a-z0-9\s]+)/gi;
+  if (!regex.test(header)) throw new Error('Response code should be valid string');
+
+  const res = header.match(regex);
+  return res.join('');
 }
 
 /**
  * Parses an HTTP header, splitting
  * by colon.
  */
-const parseHeader = function(header) {
+const parseHeader = function (header, context, request) {
   header = header.split(': ');
 
-  return { key: normalizeHeader(header[0]), value: parseValue(header[1]) };
+  return { key: normalizeHeader(header[0]), value: parseValue(header[1], context, request) };
 };
 
-const parseValue = function(value) {
-  if (/^#header/m.test(value)) {
-    return value
-      .replace(/^#header (.*);/m, function(statement, val) {
-        const expression = val.replace(/[${}]/g, '');
-        return eval(expression);
-      })
-      .replace(/\r\n?/g, '\n');
-  }
-  return value;
+const parseValue = function(value, context, request) {
+  return Monad
+    .of(value)
+    .map((value) => importHandler(value, context, request))
+    .map((value) => headerHandler(value, request))
+    .map((value) => evalHandler(value, request))
+    .join();
 };
 
 /**
@@ -56,28 +60,19 @@ const prepareWatchedHeaders = function() {
  * status code, headers and body.
  */
 const parse = function(content, file, request) {
+  const context = path.parse(file).dir + '/';
   const headers = {};
   let body;
   const bodyContent = [];
   content = content.split(/\r?\n/);
-  let status = content[0];
-  if (/^#import/m.test(status)) {
-      const context = path.parse(file).dir + '/';
+  const status = Monad
+    .of(content[0])
+    .map((value) => importHandler(value, context, request))
+    .map((value) => evalHandler(value, context, request))
+    .map(parseStatus)
+    .join();
 
-      status = parseStatus(status
-          .replace(/^#import (.*);/m, function (includeStatement, file) {
-              const importThisFile = file.replace(/['"]/g, '');
-              const content = fs.readFileSync(path.join(context, importThisFile));
-              if (importThisFile.endsWith('.js')) {
-                  return JSON.stringify(eval(content.toString()));
-              } else {
-                  return content;
-              }
-          })
-          .replace(/\r\n?/g, '\n'));
-  } else {
-      status = parseStatus(content[0]);
-  }
+
   let headerEnd = false;
   delete content[0];
 
@@ -96,23 +91,12 @@ const parse = function(content, file, request) {
     }
   });
 
-  body = bodyContent.join('\n');
 
-  if (/^#import/m.test(body)) {
-    const context = path.parse(file).dir + '/';
-
-    body = body
-      .replace(/^#import (.*);/m, function(includeStatement, file) {
-        const importThisFile = file.replace(/['"]/g, '');
-        const content = fs.readFileSync(path.join(context, importThisFile));
-        if (importThisFile.endsWith('.js')) {
-          return JSON.stringify(eval(content.toString()));
-        } else {
-          return content;
-        }
-      })
-      .replace(/\r\n?/g, '\n');
-  }
+  body = Monad
+    .of(bodyContent.join('\n'))
+    .map((value) => importHandler(value, context, request))
+    .map((value) => evalHandler(value, context, request))
+    .join();
 
   return { status: status, headers: headers, body: body };
 };
@@ -122,6 +106,7 @@ function removeBlanks(array) {
     return i;
   });
 }
+
 
 /**
  * This method will look for a header named Response-Delay. When set it

--- a/monad.js
+++ b/monad.js
@@ -1,0 +1,18 @@
+function Monad(val) {
+    this.__value = val;
+    this.map = function map(f) {
+        return Monad.of(f(this.__value));
+    }
+    this.join = function join() {
+        return this.__value;
+    }
+    this.chain = function chain(f) {
+        return this.map(f).join();
+    }
+}
+Monad.of = function(val) {
+    return new Monad(val);
+}
+
+
+module.exports = Monad;

--- a/test/mocks/eval/GET.mock
+++ b/test/mocks/eval/GET.mock
@@ -1,0 +1,4 @@
+#eval `HTTP/1.1 200 OK`;
+Content-Type: application/json
+
+#eval JSON.stringify({foo: 'bar'});

--- a/test/mocks/headerimportjs/POST.mock
+++ b/test/mocks/headerimportjs/POST.mock
@@ -1,0 +1,4 @@
+#import './code.js';
+Content-Type: application/json
+
+#import './scriptPost.js';

--- a/test/mocks/headerimportjs/code.js
+++ b/test/mocks/headerimportjs/code.js
@@ -1,1 +1,1 @@
-request.body.indexOf('foo') !== -1 ? 'HTTP/1.1 200 OK' : 'HTTP/1.1 400 Bad request'
+module.exports = request.body.indexOf('foo') !== -1 ? 'HTTP/1.1 200 OK' : 'HTTP/1.1 400 Bad request'

--- a/test/mocks/headerimportjs/code.js
+++ b/test/mocks/headerimportjs/code.js
@@ -1,0 +1,1 @@
+request.body.indexOf('foo') !== -1 ? 'HTTP/1.1 200 OK' : 'HTTP/1.1 400 Bad request'

--- a/test/mocks/headerimportjs/scriptPost.js
+++ b/test/mocks/headerimportjs/scriptPost.js
@@ -1,0 +1,3 @@
+module.exports = {
+    prop: request.body.indexOf('foo') !== -1 ? 'bar' : 'baz'
+};

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -2,6 +2,7 @@ const MockReq = require('mock-req');
 const assert = require('assert');
 const mockserver = require('./../mockserver');
 const path = require('path');
+const Monad = require('../monad');
 
 let res;
 let req;
@@ -311,6 +312,13 @@ describe('mockserver', function() {
       assert.equal(res.body, JSON.stringify({ foo: 'bar' }, null, 4));
     });
 
+    it('should be able to handle eval', function() {
+      processRequest('/eval', 'GET');
+
+      assert.equal(res.status, 200);
+      assert.deepEqual(JSON.parse(res.body), { foo: 'bar' });
+    });
+
     it('should be able to handle imports with content around import', function() {
       processRequest('/import?around=true', 'GET');
 
@@ -481,4 +489,35 @@ describe('mockserver', function() {
       });
     })
   });
+});
+
+describe('Monad methods', function() {
+    let m;
+    function fn(val) {
+        return {
+            ...val,
+            b: 2
+        };
+    }
+    const testData = { a: 1 };
+    const expectData = { a: 1, b: 2 };
+    beforeEach(function() {
+        m = Monad.of(testData);
+    });
+
+    it('Monad have static method `of`', function() {
+        assert.equal(typeof Monad.of, 'function');
+    });
+    it('Monad method `of` should return Object type Monad', function() {
+        assert.equal(m instanceof Monad, true);
+    });
+    it('Monad method `map` should recive value and return Object type Monad', function() {
+        assert.equal(m.map(fn) instanceof Monad, true);
+    });
+    it('Monad method `join` should return value', function () {
+        assert.strictEqual(m.join(), testData);
+    });
+    it('Monad method `chain` should return value', function () {
+        assert.deepEqual(m.chain(fn), expectData);
+    });
 });

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -445,6 +445,38 @@ describe('mockserver', function() {
           assert.equal(val, 0, `Value found was ${val}`);
         });
       });
+      it('response status codes depends on request case 400 Bad request', function (done) {
+          var req = new MockReq({
+              method: 'POST',
+              url: '/headerimportjs',
+              headers: {},
+          });
+          req.write(JSON.stringify({ baz: '123' }));
+          req.end();
+
+          mockserver(mocksDirectory, verbose)(req, res);
+
+          req.on('end', function () {
+              assert.equal(res.status, '400');
+              done();
+          });
+      });
+      it('response status codes depends on request case 200 OK', function (done) {
+          var req = new MockReq({
+              method: 'POST',
+              url: '/headerimportjs',
+              headers: {},
+          });
+          req.write(JSON.stringify({ foo: '123' }));
+          req.end();
+
+          mockserver(mocksDirectory, verbose)(req, res);
+
+          req.on('end', function () {
+              assert.equal(res.status, '200');
+              done();
+          });
+      });
     });
   });
 });

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -445,7 +445,9 @@ describe('mockserver', function() {
           assert.equal(val, 0, `Value found was ${val}`);
         });
       });
-      it('response status codes depends on request case 400 Bad request', function (done) {
+    });
+    describe('Custom response codes', function() {
+        it('response status codes depends on request case 400 Bad request', function (done) {
           var req = new MockReq({
               method: 'POST',
               url: '/headerimportjs',
@@ -477,6 +479,6 @@ describe('mockserver', function() {
               done();
           });
       });
-    });
+    })
   });
 });


### PR DESCRIPTION
I faced some problem when I need to have different status codes depends on request parameters (such as custom headers or body content). So I added the ability to manage response header via imported JS code.
