### PR TITLE
Add missing semicolon to JavaScript README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ module.exports = {
 };
 ```
 
-Then import the file as above `#import './script.js'`
+Then import the file as above `#import './script.js';`
 
 Dynamic values of headers can be filled with valid JS statements such as:
 


### PR DESCRIPTION
Updated README.md. Without the semicolon, the response is incorrectly a raw `#import './script.js'` instead of the executed value.